### PR TITLE
Get Docker image working on Alpine Linux base

### DIFF
--- a/packages/composer-ui/docker/Dockerfile
+++ b/packages/composer-ui/docker/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:6-alpine
 
 # Need to install extra dependencies for native modules.
-RUN apk add --no-cache make gcc g++ python git
+RUN apk add --no-cache make gcc g++ python git libc6-compat
 
 # Install the latest version by default.
 ARG VERSION=latest
 
 # Install Composer UI.
-RUN npm install --production -g composer-ui@${VERSION} && \
+RUN npm install --production -g pm2 composer-ui@${VERSION} && \
     npm cache clean
 
 # Create the composer user ID.
@@ -17,7 +17,7 @@ RUN adduser -S composer
 USER composer
 
 # Run supervisor to start the application.
-CMD [ "composer-ui", "-p", "8080" ]
+CMD [ "pm2-docker", "composer-ui", "-p", "8080" ]
 
 # Expose port 8080.
 EXPOSE 8080


### PR DESCRIPTION
The Docker image fails to build as native modules cannot be loaded. This is due to a missing compatibility library in the Alpine Linux base image. Also, I am adding the pm2 process manager to keep the Composer UI server running (incase it crashes).