### PR TITLE
Feature travis cron

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
 before_install: |
     set -ev
     set -o pipefail
+    ./.travis/should-run.sh
     npm install -g npm
     npm install -g @alrra/travis-scripts
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb

--- a/.travis/should-run.sh
+++ b/.travis/should-run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Exit on first error, print all commands.
+set -ev
+set -o pipefail
+
+# Grab the Concerto directory.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+
+if [ "${SYSTEST}" = "hlf" ] && [ "${SYSTEST_HLF}" = "ibm" ]; then
+
+  if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+	echo Valid to run hlf with ibm systest as CRON build
+  else
+    echo Not running as a PR or merge build
+    exit 0
+  fi
+fi

--- a/packages/composer-systests/scripts/run-system-tests.sh
+++ b/packages/composer-systests/scripts/run-system-tests.sh
@@ -43,7 +43,7 @@ elif [ "${SYSTEST}" = "hlf" ] && [ "${SYSTEST_HLF}" = "ibm" ]; then
     docker tag hyperledger/fabric-baseimage:x86_64-0.2.0 hyperledger/fabric-baseimage:latest
   else
     echo Not running as a PR or merge build
-    exit 1
+    exit 0
   fi
 elif [ "${SYSTEST}" = "hlf" -a "${SYSTEST_HLF}" = "" ]; then
     echo You must set SYSTEST_HLF to 'hlf' or 'ibm'

--- a/packages/composer-systests/scripts/run-system-tests.sh
+++ b/packages/composer-systests/scripts/run-system-tests.sh
@@ -31,7 +31,7 @@ if [ "${SYSTEST}" = "hlf" -a "${SYSTEST_HLF}" = "hlf" ]; then
     docker tag hyperledger/fabric-peer:x86_64-0.6.1-preview hyperledger/fabric-peer:latest
     docker pull hyperledger/fabric-baseimage:x86_64-0.2.0
     docker tag hyperledger/fabric-baseimage:x86_64-0.2.0 hyperledger/fabric-baseimage:latest
-elif [ "${SYSTEST}" = "hlf" -a "${SYSTEST_HLF}" = "ibm" ]; then
+elif [ "${SYSTEST}" = "hlf" ] && [ "${SYSTEST_HLF}" = "ibm" ] && [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
     DOCKER_FILE=${DIR}/ibm-docker-compose.yml
     docker pull ibmblockchain/fabric-membersrvc:x86_64-0.6.1-preview
     docker tag ibmblockchain/fabric-membersrvc:x86_64-0.6.1-preview ibmblockchain/fabric-membersrvc:latest

--- a/packages/composer-systests/scripts/run-system-tests.sh
+++ b/packages/composer-systests/scripts/run-system-tests.sh
@@ -31,7 +31,9 @@ if [ "${SYSTEST}" = "hlf" -a "${SYSTEST_HLF}" = "hlf" ]; then
     docker tag hyperledger/fabric-peer:x86_64-0.6.1-preview hyperledger/fabric-peer:latest
     docker pull hyperledger/fabric-baseimage:x86_64-0.2.0
     docker tag hyperledger/fabric-baseimage:x86_64-0.2.0 hyperledger/fabric-baseimage:latest
-elif [ "${SYSTEST}" = "hlf" ] && [ "${SYSTEST_HLF}" = "ibm" ] && [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
+elif [ "${SYSTEST}" = "hlf" ] && [ "${SYSTEST_HLF}" = "ibm" ]; then
+
+  if [ "${TRAVIS_EVENT_TYPE}" = "cron" ]; then
     DOCKER_FILE=${DIR}/ibm-docker-compose.yml
     docker pull ibmblockchain/fabric-membersrvc:x86_64-0.6.1-preview
     docker tag ibmblockchain/fabric-membersrvc:x86_64-0.6.1-preview ibmblockchain/fabric-membersrvc:latest
@@ -39,6 +41,10 @@ elif [ "${SYSTEST}" = "hlf" ] && [ "${SYSTEST_HLF}" = "ibm" ] && [ "${TRAVIS_EVE
     docker tag ibmblockchain/fabric-peer:x86_64-0.6.1-preview ibmblockchain/fabric-peer:latest
     docker pull hyperledger/fabric-baseimage:x86_64-0.2.0
     docker tag hyperledger/fabric-baseimage:x86_64-0.2.0 hyperledger/fabric-baseimage:latest
+  else
+    echo Not running as a PR or merge build
+    exit 1
+  fi
 elif [ "${SYSTEST}" = "hlf" -a "${SYSTEST_HLF}" = "" ]; then
     echo You must set SYSTEST_HLF to 'hlf' or 'ibm'
     echo For example:


### PR DESCRIPTION
Adding an additional check to the run-system-tests.sh to only test with the IBM HLF images *when* the build is kicked off from a daily travis 'cron' build.

#140 

