### PR TITLE
Fix github client id

### DIFF
--- a/packages/composer-connector-server/lib/connectorserver.js
+++ b/packages/composer-connector-server/lib/connectorserver.js
@@ -539,6 +539,18 @@ class ConnectorServer {
     }
 
     /**
+     * Get github client id that the user has set
+     * @param {function} callback The callback to call when complete
+     * @returns {promise} A promise that is resolved when complete
+     */
+    getGithubClientId (callback) {
+        const method = 'getGithubClientId';
+        LOG.entry(method);
+
+        return callback(null, config.clientId);
+    }
+
+    /**
      * Exchange access code for a access token from github
      * @param {string} accessCode The code obtained from authenicating with github
      * @param {function} callback The callback to call when complete

--- a/packages/composer-connector-server/test/connectorserver.js
+++ b/packages/composer-connector-server/test/connectorserver.js
@@ -107,6 +107,23 @@ describe('ConnectorServer', () => {
         });
     });
 
+    describe('#getGitHubClientId', () => {
+        it('should return the client id', (done) => {
+            connectorServer.getGithubClientId((err, response) => {
+                response.should.equal('myClient');
+                done();
+            });
+        });
+
+        it('should not return the client id if not set', (done) => {
+            configMock.clientId = null;
+            connectorServer.getGithubClientId((err, response) => {
+                should.not.exist(response);
+                done();
+            });
+        });
+    });
+
     describe('#getGitHubAccessToken', () => {
         it('should get the access token from github', (done) => {
             connectorServer.getGitHubAccessToken('1234', (err, response) => {

--- a/packages/composer-playground/src/app/import/import.component.html
+++ b/packages/composer-playground/src/app/import/import.component.html
@@ -6,7 +6,7 @@
   <section class="import-from-github">
     <div *ngIf="!gitHubAuthenticated && oAuthEnabled">
       <!-- TODO: make this client id configurable -->
-      <a href="https://github.com/login/oauth/authorize?client_id=dca17eadbdb10b65bc3f">Authenticate With Github</a>
+      <a href="https://github.com/login/oauth/authorize?client_id={{this.clientId}}">Authenticate With Github</a>
       <div id="githubDescription">
         To be able to see the samples you need to authenticate with github.
       </div>

--- a/packages/composer-playground/src/app/import/import.component.ts
+++ b/packages/composer-playground/src/app/import/import.component.ts
@@ -23,6 +23,7 @@ export class ImportComponent implements OnInit {
   private repository: string = '';
   private gitHubAuthenticated: boolean = false;
   private oAuthEnabled: boolean = false;
+  private clientId: string = null;
   private chosenNetwork = null;
 
   constructor(private adminService: AdminService,
@@ -42,7 +43,20 @@ export class ImportComponent implements OnInit {
       })
       .then((result) => {
         this.oAuthEnabled = result;
-        this.onShow();
+        if(result) {
+          return this.sampleBusinessNetworkService.getGithubClientId()
+            .then((clientId)=> {
+              if(!clientId) {
+                //shouldn't get here as oauthEnabled should return false if client id not set but just incase
+                return this.activeModal.dismiss(new Error(this.sampleBusinessNetworkService.NO_CLIENT_ID));
+              }
+
+              this.clientId = clientId;
+              this.onShow();
+            })
+        } else {
+          this.onShow();
+        }
       });
 
   }

--- a/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
+++ b/packages/composer-playground/src/app/services/samplebusinessnetwork.service.ts
@@ -180,8 +180,9 @@ export class SampleBusinessNetworkService {
   private connected: boolean = false;
 
   public OPEN_SAMPLE: boolean = false;
-  public RATE_LIMIT_MESSAGE = 'The rate limit to github api has been exceeded to fix this problem you need to setup oauth as documented <a href="https://fabric-composer.github.io/tasks/github-oauth.html"  target="_blank">here</a>';
-
+  public RATE_LIMIT_MESSAGE = 'The rate limit to github api has been exceeded, to fix this problem setup oauth as documented <a href="https://fabric-composer.github.io/tasks/github-oauth.html" target="_blank">here</a>';
+  public NO_CLIENT_ID = 'The client id for the github api has not been set, to fix this problem setup ouath as documented <a href="https://fabric-composer.github.io/tasks/github-oauth.html" target="_blank">here</a>';
+  public CLIENT_ID = null;
 
   constructor(private adminService: AdminService,
               private clientService: ClientService) {
@@ -232,8 +233,25 @@ export class SampleBusinessNetworkService {
         if (!result) {
           this.setUpGithub(null);
         }
-        resolve(result);
+        return resolve(result);
       });
+    });
+  }
+
+  getGithubClientId(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      if (this.CLIENT_ID) {
+        return resolve(this.CLIENT_ID);
+      }
+
+      this.socket.emit('/api/getGithubClientId', (error, result) => {
+        if (error) {
+          return reject(error);
+        }
+
+        this.CLIENT_ID = result;
+        return resolve(this.CLIENT_ID);
+      })
     });
   }
 

--- a/packages/site/jekylldocs/tasks/github-oauth.md
+++ b/packages/site/jekylldocs/tasks/github-oauth.md
@@ -12,6 +12,7 @@ To enable importing of samples without receiving an error when the rate limit is
 
 1. Go to [Github OAuth Applications](https://github.com/settings/developers).
 2. Register a new application.
+    - The `Authorization callback URL` should be set to `localhost:<port>/github`.
 3. On the command line navigate to the `composer-connector-server` config directory.
  
     ```


### PR DESCRIPTION
Update to make client id in ui configurable from server
Updated docs to say what the callback url should be

close fabric-composer/fabric-composer#260