### PR TITLE
Handle HTML5 mode in Express server

### DIFF
--- a/packages/composer-playground/cli.js
+++ b/packages/composer-playground/cli.js
@@ -71,7 +71,11 @@ if (process.env.COMPOSER_CONFIG) {
   });
 }
 
-app.use(express.static(path.resolve(__dirname, 'dist')));
+const dist = path.resolve(__dirname, 'dist');
+app.use(express.static(dist));
+app.all('/*', (req, res, next) => {
+  res.sendFile('index.html', { root: dist });
+});
 
 const LOG = Logger.getLog('Composer');
 

--- a/packages/composer-playground/config/webpack.prod.js
+++ b/packages/composer-playground/config/webpack.prod.js
@@ -26,7 +26,7 @@ const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 8080;
 const DOCKER = !!process.env.DOCKER;
 const DOCKER_COMPOSE = !!process.env.DOCKER_COMPOSE;
-const PLAYGROUND_API = process.env.PLAYGROUND_API || 'http://localhost:15699';
+const PLAYGROUND_API = process.env.PLAYGROUND_API || '';
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,

--- a/packages/composer-ui/cli.js
+++ b/packages/composer-ui/cli.js
@@ -71,7 +71,11 @@ if (process.env.COMPOSER_CONFIG) {
   });
 }
 
-app.use(express.static(path.resolve(__dirname, 'dist')));
+const dist = path.resolve(__dirname, 'dist');
+app.use(express.static(dist));
+app.all('/*', (req, res, next) => {
+  res.sendFile('index.html', { root: dist });
+});
 
 const LOG = Logger.getLog('Composer');
 

--- a/packages/composer-ui/config/webpack.prod.js
+++ b/packages/composer-ui/config/webpack.prod.js
@@ -26,7 +26,7 @@ const HOST = process.env.HOST || 'localhost';
 const PORT = process.env.PORT || 8080;
 const DOCKER = !!process.env.DOCKER;
 const DOCKER_COMPOSE = !!process.env.DOCKER_COMPOSE;
-const PLAYGROUND_API = process.env.PLAYGROUND_API || 'http://localhost:15699';
+const PLAYGROUND_API = process.env.PLAYGROUND_API || '';
 const METADATA = webpackMerge(commonConfig({env: ENV}).metadata, {
   host: HOST,
   port: PORT,


### PR DESCRIPTION
As per this page, we need to map all routes to index.html to support HTML5 (no hash) mode:

https://github.com/angular-ui/ui-router/wiki/Frequently-Asked-Questions#how-to-configure-your-server-to-work-with-html5mode

This should resolve #274 