### PR TITLE
Remove dependencies on v1.0 connector

### DIFF
--- a/packages/composer-admin/package.json
+++ b/packages/composer-admin/package.json
@@ -48,8 +48,7 @@
   },
   "dependencies": {
     "composer-common": "^0.4.5",
-    "composer-connector-hlf": "^0.4.5",
-    "composer-connector-hlfv1": "^0.4.5"
+    "composer-connector-hlf": "^0.4.5"
   },
   "license-check-config": {
     "src": [

--- a/packages/composer-client/package.json
+++ b/packages/composer-client/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "composer-common": "^0.4.5",
     "composer-connector-hlf": "^0.4.5",
-    "composer-connector-hlfv1": "^0.4.5",
     "uuid": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/composer-connector-server/package.json
+++ b/packages/composer-connector-server/package.json
@@ -48,7 +48,6 @@
     "composer-common": "^0.4.5",
     "composer-connector-embedded": "^0.4.5",
     "composer-connector-hlf": "^0.4.5",
-    "composer-connector-hlfv1": "^0.4.5",
     "serializerr": "^1.0.3",
     "socket.io": "^1.7.2",
     "uuid": "^3.0.1",


### PR DESCRIPTION
Installation of the v1.0 connector is broken at the moment until the Hyperledger Fabric team start regularly pushing the fabric-client and fabric-ca-client packages up to npm. We need to remove the dependency on this connector from admin, client, and connector-server until it is safe to use again.