### PR TITLE
fix(loopback): add $class to the loopbackschema

### DIFF
--- a/packages/composer-common/lib/codegen/fromcto/loopback/loopbackvisitor.js
+++ b/packages/composer-common/lib/codegen/fromcto/loopback/loopbackvisitor.js
@@ -277,6 +277,14 @@ class LoopbackVisitor {
             jsonSchema.description = `An instance of ${classDeclaration.getFullyQualifiedName()}`;
         }
 
+        // Every class declaration has a $class property.
+        jsonSchema.properties.$class = {
+            type: 'string',
+            default: classDeclaration.getFullyQualifiedName(),
+            required: false,
+            description: 'The class identifier for this type'
+        };
+
         // Walk over all of the properties of this class and its super classes.
         classDeclaration.getProperties().forEach((property) => {
 

--- a/packages/loopback-connector-composer/integration-test/businessnetworkconnector-it.js
+++ b/packages/loopback-connector-composer/integration-test/businessnetworkconnector-it.js
@@ -212,6 +212,12 @@ describe('BusinessNetworkConnector Integration Test', () => {
                         },
                         'plural' : 'systest.loopback.SimpleStringAsset',
                         'properties' : {
+                            '$class' : {
+                                'default': 'systest.loopback.SimpleStringAsset',
+                                'description': 'The class identifier for this type',
+                                'required': false,
+                                'type': 'string'
+                            },
                             'assetId' : {
                                 'description' : 'The instance identifier for this type',
                                 'id' : true,
@@ -254,6 +260,12 @@ describe('BusinessNetworkConnector Integration Test', () => {
                         },
                         'plural' : 'systest.loopback.SimpleConceptAsset',
                         'properties' : {
+                            '$class' : {
+                                'default': 'systest.loopback.SimpleConceptAsset',
+                                'description': 'The class identifier for this type',
+                                'required': false,
+                                'type': 'string'
+                            },
                             'assetId' : {
                                 'description' : 'The instance identifier for this type',
                                 'id' : true,
@@ -376,6 +388,7 @@ describe('BusinessNetworkConnector Integration Test', () => {
                 });
             })
                 .then((result) => {
+                    result.$class.should.equal('systest.loopback.SimpleParticipant');
                     result.participantId.should.equal('myParticipant');
                     result.stringValue.should.equal('Caroline');
                     result.stringValues.should.deep.equal(['Caroline', 'Church']);
@@ -456,9 +469,11 @@ describe('BusinessNetworkConnector Integration Test', () => {
 
             Promise.all([assetPromise, participantPromise])
                 .then(results => {
+                    results[0].$class.should.equal('systest.loopback.SimpleStringAsset');
                     results[0].assetId.should.equal('updateAsset');
                     results[0].stringValue.should.equal('a big car');
 
+                    results[1].$class.should.equal('systest.loopback.SimpleParticipant');
                     results[1].participantId.should.equal('updateParticipant');
                     results[1].stringValue.should.equal('Caroline');
                 })
@@ -489,6 +504,7 @@ describe('BusinessNetworkConnector Integration Test', () => {
                 });
             })
                 .then((result) => {
+                    result.$class.should.equal('systest.loopback.SimpleStringAsset');
                     result.assetId.should.equal('updateAsset');
                     result.stringValue.should.equal('a bigger car');
                 })
@@ -531,6 +547,7 @@ describe('BusinessNetworkConnector Integration Test', () => {
                 });
             })
                 .then((result) => {
+                    result.$class.should.equal('systest.loopback.SimpleParticipant');
                     result.participantId.should.equal('updateParticipant');
                     result.stringValue.should.equal('update Caroline');
                 })
@@ -597,9 +614,11 @@ describe('BusinessNetworkConnector Integration Test', () => {
 
             Promise.all([assetPromise, participantPromise])
                 .then(results => {
+                    results[0].$class.should.equal('systest.loopback.SimpleStringAsset');
                     results[0].assetId.should.equal('deleteAsset');
                     results[0].stringValue.should.equal('a big car');
 
+                    results[1].$class.should.equal('systest.loopback.SimpleParticipant');
                     results[1].participantId.should.equal('deleteParticipant');
                     results[1].stringValue.should.equal('Caroline');
                 })

--- a/packages/loopback-connector-composer/test/businessnetworkconnector.js
+++ b/packages/loopback-connector-composer/test/businessnetworkconnector.js
@@ -347,6 +347,12 @@ describe('BusinessNetworkConnector Unit Test', () => {
                     },
                     'plural' : 'org.acme.base.BaseAsset',
                     'properties' : {
+                        '$class' : {
+                            'default': 'org.acme.base.BaseAsset',
+                            'description': 'The class identifier for this type',
+                            'required': false,
+                            'type': 'string'
+                        },
                         'theValue' : {
                             'description' : 'The instance identifier for this type',
                             'id' : true,


### PR DESCRIPTION
Some json parsers are pedantic about flows that don’t match the defined schema exactly. Generated code from swagger for example fail oif the json document contains more properties than expected. As $class is always flowed on a get the swagger documentation needs to be updated to include it.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>