### PR TITLE
Removing Concerto references from documentation

### DIFF
--- a/packages/composer-website/jekylldocs/_includes/head.html
+++ b/packages/composer-website/jekylldocs/_includes/head.html
@@ -35,5 +35,5 @@
     <!-- <link href="{{site.baseurl}}/assets/css/new-style.min.css" rel="stylesheet"> -->
   {% endif %}
 
-  <!--link href="/blog/atom.xml" type="application/atom+xml" rel="alternate" title="Concerto Blog Atom Feed">-->
+  <!--link href="/blog/atom.xml" type="application/atom+xml" rel="alternate" title="Composer Blog Atom Feed">-->
 </head>

--- a/packages/composer-website/jekylldocs/index.html
+++ b/packages/composer-website/jekylldocs/index.html
@@ -35,7 +35,7 @@
     <link href="/assets/css/composer-style.css" rel="stylesheet">
 
 
-  <!--link href="/blog/atom.xml" type="application/atom+xml" rel="alternate" title="Concerto Blog Atom Feed">-->
+  <!--link href="/blog/atom.xml" type="application/atom+xml" rel="alternate" title="Composer Blog Atom Feed">-->
 </head>
 
 

--- a/packages/composer-website/jekylldocs/overview/overview.md
+++ b/packages/composer-website/jekylldocs/overview/overview.md
@@ -14,7 +14,7 @@ Fabric Composer is a set of APIs, a modeling language and
 a programming model to quickly define and deploy business networks and applications
 that allow **participants** to send **transactions** that exchange **assets**.
 
-The IBM Blockchain, based on Open Source [Hyperledger Fabric](http://www.hyperledger.org) technology, is used to store the state of assets in asset registries, while the blockchain consensus protocol ensure that transactions
+The IBM Blockchain, based on Open Source [Hyperledger Fabric](https://www.hyperledger.org) technology, is used to store the state of assets in asset registries, while the blockchain consensus protocol ensure that transactions
 are validated by concerned organizations in the business network.
 
 ## Framework Features
@@ -38,7 +38,7 @@ Definition, which contains a data model that defines the name and structure of a
 and transactions in the business network. The business network also specifies *transaction processor functions*
 (written in ES5 Javascript) that are automatically run on a Hyperledger Fabric when transactions are submitted by clients.
 
-Fabric Composer defines [Javascript APIs](https://fabric-composer.github.io/jsdoc/develop/index.html)to submit transactions and to create, retrieve, update and delete assets within asset registries.
+Fabric Composer defines [Javascript APIs](https://fabric-composer.github.io/jsdoc/index.html)to submit transactions and to create, retrieve, update and delete assets within asset registries.
 
 ### Roles, Responsibilities and Tasks
 
@@ -129,7 +129,7 @@ const BusinessNetworkDefinition = require('composer-common').BusinessNetworkDefi
 const fs = require('fs');
 
 const admin = new AdminConnection();
-const concerto = new BusinessNetworkConnection();
+const composer = new BusinessNetworkConnection();
 
 const config = {
     type: 'hlf',
@@ -168,17 +168,17 @@ return admin.createProfile('testprofile', config)
   })
   .then(() => {
       console.log('Disconnected admin');
-      return concerto.connect(CONNECTION_PROFILE_NAME, businessNetworkIdentifier, 'WebAppAdmin', 'DJY27pEnl16d');
+      return composer.connect(CONNECTION_PROFILE_NAME, businessNetworkIdentifier, 'WebAppAdmin', 'DJY27pEnl16d');
   })
   .then(() => {
       console.log('Connected client to ' + businessNetworkIdentifier );
-      return concerto.addAssetRegistry('com.ibm.concerto.mozart.Farmer', 'Farmer Registry');
+      return composer.addAssetRegistry('com.ibm.composer.mozart.Farmer', 'Farmer Registry');
   })
   .then((registry) => {
       console.log('Found animal asset registry ' + registry );
   })
   .then(() => {
-      return concerto.disconnect();
+      return composer.disconnect();
   })
   .then(() => {
       console.log('Done');

--- a/packages/composer-website/jekylldocs/reference/MeetTheModules.md
+++ b/packages/composer-website/jekylldocs/reference/MeetTheModules.md
@@ -42,4 +42,4 @@ This provides command line tools to provide the ability to deploy and managed bu
 ```
 npm install -g composer-cli
 ```
-If you wish however you can instgall this as a local dependancy, but you could need to access the cli.js node class directly rather than used the `concerto` command.
+If you wish however you can instgall this as a local dependancy, but you could need to access the cli.js node class directly rather than used the `composer` command.

--- a/packages/composer-website/jekylldocs/reference/composer.generator.tests.md
+++ b/packages/composer-website/jekylldocs/reference/composer.generator.tests.md
@@ -22,7 +22,7 @@ composer generator tests -d <project-directory> -a <business-network-archive> -i
 ### Options
 ```
 --help                        Show help  [boolean]
---projectDir, -d              The directory of your your concerto project  [string] [required]
+--projectDir, -d              The directory of your your composer project  [string] [required]
 --networkArchiveLocation, -a  The location of the network archive zip file  [string] [required]
 --testDirName -t              The name of the projects test directory  [string] [optional] default: test
 --enrollId, -i                The enrollment ID of the user  [string] [required]

--- a/packages/composer-website/jekylldocs/reference/cto_language.md
+++ b/packages/composer-website/jekylldocs/reference/cto_language.md
@@ -52,7 +52,7 @@ the vin field. Identifying fields must be Strings.
 4. An optional super-type, which the resource definition extends.
 5. An optional 'abstract' declaration, to indicate that this type cannot be created
 6. A set of named fields (data owned by the resource, using a has-a relationship)
-7. A set of relationships to other concerto types that are not owned by the resource
+7. A set of relationships to other Composer types that are not owned by the resource
 but that may be referenced from the resource. Relationships are unidirectional.
 
     ```
@@ -122,7 +122,7 @@ concept UnitedStatesAddress extends Address {
 
 ### Primitive types
 
-Concerto resources are defined in terms of the following primitive types:
+Composer resources are defined in terms of the following primitive types:
 
 1. String : a UTF8 encoded String
 2. Double : a double precision 64 bit numeric value
@@ -134,7 +134,7 @@ and UTZ offset
 
 ### Arrays
 
-All types in Concerto may be declared as arrays using the [] notation. Hence
+All types in Composer may be declared as arrays using the [] notation. Hence
 
     Integer[] integerArray
 
@@ -147,7 +147,7 @@ Is an array of relationships to the Animal type, stored in a field called
 
 ### Relationships
 
-A relationship in the Concerto language is a tuple composed of:
+A relationship in the Composer language is a tuple composed of:
 
 1. The namespace of the type being referenced
 2. The type name of the type being referenced
@@ -167,7 +167,7 @@ exists or the information in the relationship is invalid.
 
 ### Field Validators
 
-String fields may include an optional regular expression, which is used to validate the contents of the field. Careful use of field validators allows Concerto to perform rich data validation, leading to fewer errors and less boilerplate code.
+String fields may include an optional regular expression, which is used to validate the contents of the field. Careful use of field validators allows Composer to perform rich data validation, leading to fewer errors and less boilerplate code.
 
 The example below declares that the `Farmer` participant contains a field `postcode` that must conform to the regular expression for valid UK postcodes.
 

--- a/packages/composer-website/jekylldocs/reference/glossary.md
+++ b/packages/composer-website/jekylldocs/reference/glossary.md
@@ -42,18 +42,18 @@ Fabric Composer has been developed to permit architects and developers to use a 
 
 **Model** which describes, using a domain specific language, the business assets and the participants in the Business Network. This model is in effect the entity-relationship or static object structure of the overall business network.  To provide dynamic behaviour this is coupled with a
 
-**Transaction Processor Functions** written in JavaScript that act on assets and participants to either create, update or delete properties on assets and participants. The set of scripts that define transaction processor functions, and Model (which may be split between multiple source files) form the Business Network Definition. In order to use these with the Concerto system, they are bundled together to form a
+**Transaction Processor Functions** written in JavaScript that act on assets and participants to either create, update or delete properties on assets and participants. The set of scripts that define transaction processor functions, and Model (which may be split between multiple source files) form the Business Network Definition. In order to use these with the Composer system, they are bundled together to form a
 
-**Business Network Archive** that can be deployed as an administrative action to the Concerto system running on a Hyperledger fabric.
+**Business Network Archive** that can be deployed as an administrative action to the Composer system running on a Hyperledger fabric.
 
 # Development of a system using Fabric Composer
 
-There are two 'phases' to running an application using the Concerto framework; the Business Network Definition should be deployed to a Hyperledger Fabric; then the application will run against this fabric, but using APIs applicable to the business model.
+There are two 'phases' to running an application using the Composer framework; the Business Network Definition should be deployed to a Hyperledger Fabric; then the application will run against this fabric, but using APIs applicable to the business model.
 
-The Concerto system is defined in a number of [modules](MeetTheModules.html).
+The Composer system is defined in a number of [modules](MeetTheModules.html).
 
 **Fabric Composer Client API** This is the API that is used by applications to connect to a business network and submit transactions. These end applications might be either command line, gui web applications using for example Angular-2.  These APIs permit CRUD operations on the assets that have been defined in the model. It also permits the submission of the transactions to be executed to update assets for example.
 
-**Fabric Composer Admin API** is an administrative API to build admin applications. This can deploy and update business network definitions on the concerto fabric runtime.
+**Fabric Composer Admin API** is an administrative API to build admin applications. This can deploy and update business network definitions on the Composer fabric runtime.
 
 To facilitate the application development process there are helper tools to permit the development.

--- a/packages/composer-website/jekylldocs/reference/js_scripts.md
+++ b/packages/composer-website/jekylldocs/reference/js_scripts.md
@@ -21,7 +21,7 @@ Decorators within documentation comments are used to annotate the functions with
 
 ## Sample Script
 
-The script below defines two transaction processor functions, called `onAnimalMovementDeparture` and `onAnimalMovementArrival`. Note that the model files within the `BusinessNetworkDefinition` must define the two transaction types `com.ibm.concerto.mozart.AnimalMovementDeparture` and `com.ibm.concerto.mozart.AnimalMovementArrival`.
+The script below defines two transaction processor functions, called `onAnimalMovementDeparture` and `onAnimalMovementArrival`. Note that the model files within the `BusinessNetworkDefinition` must define the two transaction types `com.ibm.composer.mozart.AnimalMovementDeparture` and `com.ibm.composer.mozart.AnimalMovementArrival`.
 
         ```
         'use strict';
@@ -31,7 +31,7 @@ The script below defines two transaction processor functions, called `onAnimalMo
 
         /**
         * A transaction processor for AnimalMovementDeparture
-        * @param  {com.ibm.concerto.mozart.AnimalMovementDeparture} movementDeparture - the transaction to be processed
+        * @param  {com.ibm.composer.mozart.AnimalMovementDeparture} movementDeparture - the transaction to be processed
         * @transaction
         */
         function onAnimalMovementDeparture(movementDeparture) {
@@ -40,7 +40,7 @@ The script below defines two transaction processor functions, called `onAnimalMo
 
         /**
         * A transaction processor for AnimalMovementArrival
-        * @param  {com.ibm.concerto.mozart.AnimalMovementArrival} movementArrival - the transaction to be processed
+        * @param  {com.ibm.composer.mozart.AnimalMovementArrival} movementArrival - the transaction to be processed
         * @transaction
         */
         function onAnimalMovementArrival(movementArrival) {

--- a/packages/composer-website/jekylldocs/tasks/diagnostics.md
+++ b/packages/composer-website/jekylldocs/tasks/diagnostics.md
@@ -14,7 +14,7 @@ If something should ever go wrong with an application, what should you do about 
 
 Let's look at the Getting Started application, and use that to explain how to get diagnostics out of the Framework.
 
-Key Point: This is a framework - so your application will need to have it's own logging framework. Plus, your application could also have configuration information to control Fabric Composer's own logging. Concerto does use the Winston logging module by default - and will use the Config module to look for any configuration information. If none is found, then a set of defaults will be used.
+Key Point: This is a framework - so your application will need to have it's own logging framework. Plus, your application could also have configuration information to control Fabric Composer's own logging. Composer does use the Winston logging module by default - and will use the Config module to look for any configuration information. If none is found, then a set of defaults will be used.
 
 Note that the config module does write out a warning, if there are no configuration files set. Eg. `WARNING: No configurations found in configuration directory`. This can be suppressed with an environment variable if you are happy with the defaults and don't wish to use config in your application. See more information [here](https://github.com/lorenwest/node-config/wiki/Environment-Variables#suppress_no_config_warning).
 

--- a/packages/composer-website/jekylldocs/tasks/diagnostics.md
+++ b/packages/composer-website/jekylldocs/tasks/diagnostics.md
@@ -59,7 +59,7 @@ For example
        "businessNetworkIdentifier" : "digitalproperty-network",
        "connectionProfile" :"defaultProfile"
     },
-    "ConcertoConfig": {
+    "ComposerConfig": {
        "debug": {
          "logger": "default",
          "config": {
@@ -79,7 +79,7 @@ For example
 
 }
 ```
-The first section is specific to the Getting Started application, the second `ConcertoConfig` section is for the Fabric Composer.
+The first section is specific to the Getting Started application, the second `ComposerConfig` section is for the Fabric Composer.
 
 - `logger` is used to refer the module that does actual logging. default is implying that this is the winston framework
 - `config` is passed to the logger to control what it does.  So this section is specific to the logger in use.
@@ -89,7 +89,7 @@ The first section is specific to the Getting Started application, the second `Co
 The standard way of enabling node.js applications for debug is to use the `DEBUG` environment variable. So therefore
 
 ```
-DEBUG=concerto:* node myApplication.js
+DEBUG=composer:* node myApplication.js
 ```
 
 Will enabled more tracing - this then will use the levels marked as `enabledLevel` in the configuration above.
@@ -117,7 +117,7 @@ matthew@matthew-VirtualBox:~$ cat ~/.composer-connection-profiles/defaultProfile
     "membershipServicesURL": "grpc://localhost:7054",
     "peerURL": "grpc://localhost:7051",
     "eventHubURL": "grpc://localhost:7053",
-    "keyValStore": "/home/matthew/.concerto-credentials",
+    "keyValStore": "/home/matthew/.composer-credentials",
     "deployWaitTime": "300",
     "invokeWaitTime": "100",
     "networks": {

--- a/packages/composer-website/jekylldocs/tasks/manual_prerequisites.md
+++ b/packages/composer-website/jekylldocs/tasks/manual_prerequisites.md
@@ -53,7 +53,7 @@ development. We have even created an experimental CTO file syntax highlighting p
 
 Suggested Plugins:
 
-Code Highlighting: On top of the existing code highlighting support there is a plugin for model file highlighting. [Atom Concerto Syntax Highlighter](https://github.ibm.com/Blockchain-WW-Labs/Concerto-Atom)
+Code Highlighting: On top of the existing code highlighting support there is a plugin for model file highlighting. [Atom Composer Syntax Highlighter](https://github.ibm.com/Blockchain-WW-Labs/Concerto-Atom)
 
 UI: [File Icons](https://atom.io/packages/file-icons) is a useful UI enhancement to show different icons for different files.
 

--- a/packages/composer-website/jekylldocs/tasks/prerequisites.md
+++ b/packages/composer-website/jekylldocs/tasks/prerequisites.md
@@ -69,7 +69,7 @@ development. We have even created an experimental CTO file syntax highlighting p
 
 Suggested Plugins:
 
-Code Highlighting: On top of the existing code highlighting support there is a plugin for model file highlighting. [Atom Concerto Syntax Highlighter](https://github.ibm.com/Blockchain-WW-Labs/Concerto-Atom)
+Code Highlighting: On top of the existing code highlighting support there is a plugin for model file highlighting. [Atom Composer Syntax Highlighter](https://github.ibm.com/Blockchain-WW-Labs/Concerto-Atom)
 
 UI: [File Icons](https://atom.io/packages/file-icons) is a useful UI enhancement to show different icons for different files.
 

--- a/packages/composer-website/scripts/changelog.sh
+++ b/packages/composer-website/scripts/changelog.sh
@@ -3,7 +3,7 @@
 # Exit on first error, print all commands.
 set -ev
 
-# Grab the Concerto directory.
+# Grab the Composer directory.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 

--- a/packages/composer-website/scripts/generate-uml.sh
+++ b/packages/composer-website/scripts/generate-uml.sh
@@ -3,7 +3,7 @@
 # Exit on first error, print all commands.
 set -ev
 
-# Grab the Concerto directory.
+# Grab the Composer directory.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Check for the system tests.

--- a/packages/composer-website/scripts/setup-jekyll.sh
+++ b/packages/composer-website/scripts/setup-jekyll.sh
@@ -4,7 +4,7 @@
 
 set -ev
 
-# Grab the Concerto-Docs directory.
+# Grab the Composer-Docs directory.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 


### PR DESCRIPTION
Removing all references to Concerto (as far as reasonably possible) and replacing with Composer in preparation for a conref to replace them when the system is set up.

## Checklist
[ ]  A link to the issue/user story that the pull request relates to
[ ]  Design of the fix


## Issue/User story

Previously, lots of references in both codeblocks/snippets and plaintext to Concerto, have replaced with Composer and verified with Matthew White that the ones in codeblocks can be safely changed. There are still a couple of references to concerto, but they're in links to the GitHub repository storing the syntax highlighter for Atom: https://github.ibm.com/Blockchain-WW-Labs/Concerto-Atom


## Design of the fix

Having only references to Composer makes it lots easier to replace these references with conrefs.

## Validation of the fix

Unvalidated as yet, but am working on getting VirtualBox set up so I can run local builds of the documentation.

@mbwhite If you wouldn't mind taking a quick look at the changes, just to verify. I don't want to break anything on my first pull request!