### PR TITLE
Documentation Impact section added to issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -31,6 +31,9 @@
 ## Context
 <!--- How has this bug affected you? What were you trying to accomplish? -->
 
+## Documentation Impact
+<!-- Will this affect documentation, either by invalidating existing docs, or requiring the creation of new documentation? If yes, give a brief outline below and add the "Docs" label to this issue. -->
+
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 * Version used:


### PR DESCRIPTION
Updating the issue template to include documentation impact, and adding an explanation of expected content in the section, as well as a reminder to add the Docs label if there is any impact. 

## Design of the fix

Adding this section should hopefully make documentation workload tracking easier, and will let me see the landscape a little easier in terms of where to focus efforts.

## Validation of the fix

Posted plans to Rocket.Chat fabric-composer-dev and people seemed reasonably happy with the idea of the change.