### PR TITLE
Stop trimming final newline in PEM certificates (#427)

### DIFF
--- a/packages/composer-connector-hlf/.istanbul.yml
+++ b/packages/composer-connector-hlf/.istanbul.yml
@@ -4,7 +4,7 @@ instrumentation:
         - scripts/**
 check:
     global:
-        statements: 95
-        branches: 95
-        lines: 95
-        functions: 90
+        statements: 100
+        branches: 100
+        lines: 100
+        functions: 100

--- a/packages/composer-connector-hlf/lib/hfcconnectionmanager.js
+++ b/packages/composer-connector-hlf/lib/hfcconnectionmanager.js
@@ -118,6 +118,8 @@ class HFCConnectionManager extends ConnectionManager {
                     // Check to see that the certificate is not just whitespace.
                     let certificate = connectOptions.certificate.trim();
                     if (certificate) {
+                        // Certificates *must* end with a trailing newline.
+                        certificate += '\n';
                         grpcOptions.pem = certificate;
                     }
                 }

--- a/packages/composer-connector-hlf/test/hfcconnectionmanager.js
+++ b/packages/composer-connector-hlf/test/hfcconnectionmanager.js
@@ -343,11 +343,11 @@ describe('HFCConnectionManager', () => {
 
                             // Check for the correct interactions with hfc.
                             sinon.assert.calledOnce(mockChain.setMemberServicesUrl);
-                            sinon.assert.calledWith(mockChain.setMemberServicesUrl, connectOptions.membershipServicesURL, { pem: '=== such certificate ===' });
+                            sinon.assert.calledWith(mockChain.setMemberServicesUrl, connectOptions.membershipServicesURL, { pem: '=== such certificate ===\n' });
                             sinon.assert.calledOnce(mockChain.addPeer);
-                            sinon.assert.calledWith(mockChain.addPeer, connectOptions.peerURL, { pem: '=== such certificate ===' });
+                            sinon.assert.calledWith(mockChain.addPeer, connectOptions.peerURL, { pem: '=== such certificate ===\n' });
                             sinon.assert.calledOnce(mockChain.eventHubConnect);
-                            sinon.assert.calledWith(mockChain.eventHubConnect, 'grpc://vp1', { pem: '=== such certificate ===' });
+                            sinon.assert.calledWith(mockChain.eventHubConnect, 'grpc://vp1', { pem: '=== such certificate ===\n' });
                             return true;
 
                         });
@@ -404,6 +404,24 @@ describe('HFCConnectionManager', () => {
                 peerURL: 'grpc://vp0',
                 eventHubURL: 'grpc://vp1'
             };
+        });
+
+        it('should throw for a connection not created by the connection manager', () => {
+            let mockConnection = sinon.createStubInstance(HFCConnection);
+            mockConnection.getIdentifier.returns('not a real identifier');
+            (() => {
+                connectionManager.onDisconnect(mockConnection);
+            }).should.throw(/not created by connection manager/);
+        });
+
+        it('should throw for a connection already closed by the connection manager', () => {
+            let mockConnection = sinon.createStubInstance(HFCConnection);
+            let mockChain = sinon.createStubInstance(hfcChain);
+            mockConnection.getIdentifier.returns('not a real identifier');
+            connectionManager.chainPool['not a real identifier'] = { count: 0, chain: mockChain };
+            (() => {
+                connectionManager.onDisconnect(mockConnection);
+            }).should.throw(/already closed/);
         });
 
         it('should call onDisconnect when client connection is disconnected', function() {


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
[ ]  A link to the issue/user story that the pull request relates to
[ ]  How to recreate the problem without the fix
[ ]  Design of the fix
[ ]  How to prove that the fix works
[ ]  Automated tests that prove the fix keeps on working
[ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
#427 Composer fails to work reliably with IBM HSBN service

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [StackOverflow issues](http://stackoverflow.com/tags/fabric-composer)
- [ ] [GitHub Issues](https://github.com/fabric-composer/fabric-composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/fabric-composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to StackOverflow questions are possible documentation sources -->