### PR TITLE
Cache the node_modules directory as per Travis CI guidance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,10 @@ node_js:
 matrix:
     include:
         - env: DOCS=full FC_TASK=docs
-          sudo: false
-          node_js :
-            - '6'
         - env: SYSTEST=embedded FC_TASK=systest
         - env: SYSTEST=web FC_TASK=systest
-        - env: SYSTEST=hlf SYSTEST_HLF=hlf  FC_TASK=systest
-          sudo: required
-          services:
-            - docker
+        - env: SYSTEST=hlf SYSTEST_HLF=hlf FC_TASK=systest
         - env: SYSTEST=hlf SYSTEST_HLF=ibm FC_TASK=systest
-          sudo: required
-          services:
-            - docker
 dist: trusty
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ deploy:
     skip_cleanup: true
     on:
         branch: master
-cache: false
+cache:
+  directories:
+    - node_modules
 sudo: required
 notifications:
   pushover:

--- a/packages/composer-playground/config/webpack.common.js
+++ b/packages/composer-playground/config/webpack.common.js
@@ -194,7 +194,7 @@ module.exports = function (options) {
 
         {
           test: /\.js$/,
-          exclude: /(node_modules(?!\/composer)|bower_components)/,
+          exclude: /(node_modules(?!\/(composer|yallist))|bower_components)/,
           loader: 'babel-loader',
           query: {
             presets: [require.resolve('babel-preset-es2015')]

--- a/packages/composer-ui/config/webpack.common.js
+++ b/packages/composer-ui/config/webpack.common.js
@@ -190,7 +190,7 @@ module.exports = function (options) {
 
         {
           test: /\.js$/,
-          exclude: /(node_modules(?!\/composer)|bower_components)/,
+          exclude: /(node_modules(?!\/(composer|yallist))|bower_components)/,
           loader: 'babel-loader',
           query: {
             presets: [require.resolve('babel-preset-es2015')]


### PR DESCRIPTION
This increases build times even further, and now applies to all packages since we started using Lerna's "hoist" mode. Also, the docs build seems to be really slow - I think this is down to it using the Trusty container beta, rather than the Trusty VM - moving to the Trusty VM speeds things up.