### PR TITLE
Fix transaction submit to hide id/timestamp

### DIFF
--- a/packages/composer-playground/src/app/transaction/transaction.component.html
+++ b/packages/composer-playground/src/app/transaction/transaction.component.html
@@ -29,7 +29,7 @@
     </div>
   </section>
   <footer>
-    <h2>Just need quick test data? <button class="action" type="button" (click)="generateResource()">Generate Random Data</button></h2>
+    <h2>Just need quick test data? <button class="action" type="button" (click)="generateTransactionDeclaration({ generate: true })">Generate Random Data</button></h2>
     <button type="button" class="secondary" (click)="activeModal.dismiss();">
       <span>Cancel</span>
     </button>


### PR DESCRIPTION
## Checklist
 - [ ] #404
 - [ ]  givein in above
 - [ ]  Use a map to hold key/value pairs that are added/removed 
 - [ ]  accept 
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
issue #404

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2..
4.


## Design of the fix
Used a map to hold parameters that are to be hidden from view. Considered pushing/pulling at areas, but decided that holding parameters in a map would be safer and more extensible.

No longer "stubbing out" a blank transaction, but using the generate instance method - #409 is editing this function to take additional parameters to generate a meaningful empty declaration. A single parameter change will be required here to enable that change once available.

## Validation of the fix
manual testing against all demo cto files