### PR TITLE
Stop using fully qualified identifier for some relationships

### DIFF
--- a/packages/composer-common/lib/serializer/jsongenerator.js
+++ b/packages/composer-common/lib/serializer/jsongenerator.js
@@ -232,12 +232,8 @@ class JSONGenerator {
         } else {
             throw new Error('Did not find a relationship for ' + relationshipDeclaration.getFullyQualifiedTypeName() + ' found ' + relationship );
         }
-        let relationshipText = identifiable.getIdentifier();
-        if(relationshipDeclaration.getNamespace() !==  identifiable.getNamespace() ) {
-            relationshipText = identifiable.getFullyQualifiedIdentifier();
-        }
 
-        return relationshipText;
+        return identifiable.getIdentifier();
     }
 }
 

--- a/packages/composer-common/test/serializer/jsongenerator.js
+++ b/packages/composer-common/test/serializer/jsongenerator.js
@@ -326,8 +326,7 @@ describe('JSONGenerator', () => {
             let mockRelationship = sinon.createStubInstance(Relationship);
             mockRelationship.getIdentifier.returns('DOGE_1');
             mockRelationship.getNamespace.returns('org.elsewhere');
-            mockRelationship.getFullyQualifiedIdentifier.returns('org.elsewhere.MyAsset1#DOGE_1');
-            jsonGenerator.getRelationshipText(relationshipDeclaration1, mockRelationship).should.equal('org.elsewhere.MyAsset1#DOGE_1');
+            jsonGenerator.getRelationshipText(relationshipDeclaration1, mockRelationship).should.equal('DOGE_1');
         });
 
         it('should throw an error for a resource if not permitted', () => {


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
#469 Relationships to types in other namespaces get corrupted

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [StackOverflow issues](http://stackoverflow.com/tags/fabric-composer)
- [ ] [GitHub Issues](https://github.com/fabric-composer/fabric-composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/fabric-composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to StackOverflow questions are possible documentation sources -->