### PR TITLE
Move Vertical Location of Submit Transaction (#420 :32)

### DIFF
--- a/packages/composer-playground/src/app/test/test.component.scss
+++ b/packages/composer-playground/src/app/test/test.component.scss
@@ -6,6 +6,7 @@ app-test {
   width: 100%;
 
   .side-bar {
+
     .registries {
       & > * {
         padding: $space-smedium $space-large;
@@ -25,6 +26,7 @@ app-test {
     }
 
     .side-button {
+      flex : 1;
       margin: 0 auto;
 
       .button-item {


### PR DESCRIPTION
Submit transaction button became shifted to bottom of screen through high level application of padding, need to apply local change in test side-bar to revert the submit button to the correct space

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
#420 (32)

## Steps to Reproduce
Open browser, look at button location


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [StackOverflow issues](http://stackoverflow.com/tags/fabric-composer)
- [ ] [GitHub Issues](https://github.com/fabric-composer/fabric-composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/fabric-composer)

## Design of the fix
move button location by using flex 1

## Validation of the fix
open browser look at button
