### PR TITLE
fix(v1): queryChainCode Error Handling changed

### DIFF
--- a/packages/composer-connector-hlfv1/lib/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/lib/hlfconnection.js
@@ -381,8 +381,9 @@ class HLFConnection extends Connection {
         }
 
         proposalResponses.forEach((proposalResponse) => {
-            if (proposalResponse.error) {
-                throw proposalResponse.error;
+            if (proposalResponse instanceof Error) {
+                console.log('throwing proposal response');
+                throw proposalResponse;
             } else if (proposalResponse.response.status === 200) {
                 return true;
             }
@@ -550,6 +551,10 @@ class HLFConnection extends Connection {
                     throw new Error('No payloads were returned from the query request:' + functionName);
                 }
                 const payload = payloads[0];
+                if (payload instanceof Error) {
+                    // will be handled by the catch block
+                    throw payload;
+                }
                 LOG.exit(payload);
                 return payload;
             })

--- a/packages/composer-connector-hlfv1/test/hlfconnection.js
+++ b/packages/composer-connector-hlfv1/test/hlfconnection.js
@@ -386,7 +386,7 @@ describe('HLFConnection', () => {
             // This is the generated nonce.
             sandbox.stub(utils, 'getNonce').returns('11111111-1111-1111-1111-111111111111');
             // This is the deployment proposal and response (from the peers).
-            const proposalResponses = [ {'error': new Error('such error')} ];
+            const proposalResponses = [ new Error('such error') ];
             const proposal = { proposal: 'i do' };
             const header = { header: 'gooooal' };
             // This is the generated transaction
@@ -725,6 +725,22 @@ describe('HLFConnection', () => {
                 .should.be.rejectedWith(/No payloads were returned from the query request/);
         });
 
+        it('should throw any responses that are errors', () => {
+            // This is the generated nonce.
+            sandbox.stub(utils, 'getNonce').returns('11111111-1111-1111-1111-111111111111');
+            // This is the generated transaction
+            mockChain.buildTransactionID.returns('00000000-0000-0000-0000-000000000000');
+            // mock out getUserContext version in case we need to return to using this one
+            mockChain.buildTransactionID_getUserContext.resolves('00000000-0000-0000-0000-000000000000');
+            // This is the transaction proposal and response (from the peers).
+            const response = [ new Error('such error') ];
+            // This is the response from the chaincode.
+            mockChain.queryByChaincode.resolves(response);
+            return connection.queryChainCode(mockSecurityContext, 'myfunc', ['arg1', 'arg2'])
+                .should.be.rejectedWith(/such error/);
+
+        });
+
     });
 
     describe('#invokeChainCode', () => {
@@ -817,7 +833,7 @@ describe('HLFConnection', () => {
             // mock out getUserContext version in case we need to return to using this one
             mockChain.buildTransactionID_getUserContext.resolves('00000000-0000-0000-0000-000000000000');
             // This is the transaction proposal and response (from the peers).
-            const proposalResponses = [ {'error': new Error('such error')} ];
+            const proposalResponses = [ new Error('such error') ];
             const proposal = { proposal: 'i do' };
             const header = { header: 'gooooal' };
             mockChain.sendTransactionProposal.resolves([ proposalResponses, proposal, header ]);


### PR DESCRIPTION
NodeSDK has changed the way errors are done on queryChainCode

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>

<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [StackOverflow issues](http://stackoverflow.com/tags/fabric-composer)
- [ ] [GitHub Issues](https://github.com/fabric-composer/fabric-composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/fabric-composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to StackOverflow questions are possible documentation sources -->
