### PR TITLE
Generate valid empty/default JSON for new resources

### DIFF
--- a/packages/composer-common/lib/factory.js
+++ b/packages/composer-common/lib/factory.js
@@ -17,6 +17,7 @@
 const debug = require('debug')('ibm-concerto');
 const Globalize = require('./globalize');
 const InstanceGenerator = require('./serializer/instancegenerator');
+const ValueGeneratorFactory = require('./serializer/valuegenerator');
 const Relationship = require('./model/relationship');
 
 const Resource = require('./model/resource');
@@ -135,10 +136,12 @@ class Factory {
 
         if(options.generate) {
             let visitor = new InstanceGenerator();
+            const generator = options.withSampleData ? ValueGeneratorFactory.sample() : ValueGeneratorFactory.default();
             let parameters = {
                 stack: new TypedStack(newObj),
                 modelManager: this.modelManager,
-                factory: this
+                factory: this,
+                valueGenerator: generator
             };
             classDecl.accept(visitor, parameters);
         }

--- a/packages/composer-common/lib/serializer/instancegenerator.js
+++ b/packages/composer-common/lib/serializer/instancegenerator.js
@@ -20,8 +20,8 @@ const Field = require('../introspect/field');
 const leftPad = require('left-pad');
 const ModelUtil = require('../modelutil');
 const RelationshipDeclaration = require('../introspect/relationshipdeclaration');
-const randomWords = require('random-words');
 const Util = require('../util');
+const ValueGeneratorFactory = require('./valuegenerator');
 
 /**
  * Generate sample instance data for the specified class declaration
@@ -99,20 +99,21 @@ class InstanceGenerator {
      */
     getSampleValue(field, parameters) {
         let type = field.getFullyQualifiedTypeName();
+        const valueGenerator = parameters.valueGenerator || ValueGeneratorFactory.default();
         if (ModelUtil.isPrimitiveType(type)) {
             switch(type) {
             case 'DateTime':
-                return new Date(Math.random() * Date.now());
+                return valueGenerator.getDateTime();
             case 'Integer':
-                return Math.round(Math.random() * Math.pow(2, 16));
+                return valueGenerator.getInteger();
             case 'Long':
-                return Math.round(Math.random() * Math.pow(2, 32));
+                return valueGenerator.getLong();
             case 'Double':
-                return Number((Math.random() * Math.pow(2, 8)).toFixed(3));
+                return valueGenerator.getDouble();
             case 'Boolean':
-                return Math.round(Math.random()) === 1;
+                return valueGenerator.getBoolean();
             default:
-                return randomWords({min: 1, max: 5}).join(' ');
+                return valueGenerator.getString();
             }
         }
         let classDeclaration = parameters.modelManager.getType(type);

--- a/packages/composer-common/lib/serializer/valuegenerator.js
+++ b/packages/composer-common/lib/serializer/valuegenerator.js
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const randomWords = require('random-words');
+
+/**
+ * Factory providing static methods to create ValueGenerator instances.
+ * @private
+ */
+class ValueGeneratorFactory {
+    /**
+     * Create a value generator that supplies default values.
+     * @return {ValueGenerator} a value generator.
+     */
+    static default() {
+        return new ValueGenerator();
+    }
+
+    /**
+     * Create a value generator that supplies randomly generated sample values.
+     * @return {ValueGenerator} a value generator.
+     */
+    static sample() {
+        return new SampleValueGenerator();
+    }
+}
+
+/**
+ * Default value generator.
+ * @private
+ */
+class ValueGenerator {
+    /**
+     * This constructor should not be called directly.
+     * @private
+     */
+    constructor() {
+        this.currentDate = new Date();
+    }
+
+    /**
+     * Get a default DateTime value.
+     * @return {Date} a date value.
+     */
+    getDateTime() {
+        return this.currentDate;
+    }
+
+    /**
+     * Get a default Integer value.
+     * @return {number} an Integer value.
+     */
+    getInteger() {
+        return 0;
+    }
+
+    /**
+     * Get a default Long value.
+     * @return {number} a Long value.
+     */
+    getLong() {
+        return 0;
+    }
+
+    /**
+     * Get a default Double value.
+     * @return {string} a Double value.
+     */
+    getDouble() {
+        return Number(0).toFixed(3);
+    }
+
+    /**
+     * Get a default Boolean value.
+     * @return {boolean} a Boolean value.
+     */
+    getBoolean() {
+        return false;
+    }
+
+    /**
+     * Get a default String value.
+     * @return {string} a String value.
+     */
+    getString() {
+        return '';
+    }
+}
+
+/**
+ * Sample data value generator.
+ * @private
+ */
+class SampleValueGenerator extends ValueGenerator {
+    /**
+     * This constructor should not be called directly.
+     * @private
+     */
+    constructor() {
+        super();
+    }
+
+    /**
+     * Get a randomly generated sample Integer value.
+     * @return {number} an Integer value.
+     */
+    getInteger() {
+        return Math.round(Math.random() * Math.pow(2, 16));
+    }
+
+    /**
+     * Get a randomly generated sample Long value.
+     * @return {number} a Long value.
+     */
+    getLong() {
+        return Math.round(Math.random() * Math.pow(2, 32));
+    }
+
+    /**
+     * Get a randomly generated sample Double value.
+     * @return {string} a Double value.
+     */
+    getDouble() {
+        return Number((Math.random() * Math.pow(2, 8)).toFixed(3));
+    }
+
+    /**
+     * Get a randomly generated sample Boolean value.
+     * @return {boolean} a Boolean value.
+     */
+    getBoolean() {
+        return Math.round(Math.random()) === 1;
+    }
+
+    /**
+     * Get a randomly generated sample String value.
+     * @return {string} a String value.
+     */
+    getString() {
+        return randomWords({min: 1, max: 5}).join(' ');
+    }
+}
+
+module.exports = ValueGeneratorFactory;

--- a/packages/composer-playground/src/app/resource/resource.component.html
+++ b/packages/composer-playground/src/app/resource/resource.component.html
@@ -25,7 +25,7 @@
     </section>
   </section>
   <footer>
-    <p class="footer-text" *ngIf="!editMode()">Just need quick test data? <button type="button" class="icon" (click)="generateResource()"><u>Generate Random Data</u></button></p>
+    <p class="footer-text" *ngIf="!editMode()">Just need quick test data? <button type="button" class="icon" (click)="generateSampleData()"><u>Generate Random Data</u></button></p>
     <button type="button" class="secondary" (click)="activeModal.close();">
       <span>Cancel</span>
     </button>

--- a/packages/composer-playground/src/app/resource/resource.component.ts
+++ b/packages/composer-playground/src/app/resource/resource.component.ts
@@ -80,12 +80,12 @@ export class ResourceComponent implements OnInit {
 
             if (this.editMode()) {
                 this.resourceAction = 'Update';
-                this.resourceDefinition = this.getResourceJSON();
             } else {
                 // Stub out json definition
                 this.resourceAction = 'Create New';
-                this.resourceDefinition = this.generateDefinitionStub(this.registryID, modelClassDeclaration);
+                this.generateResource();
             }
+            this.resourceDefinition = this.getResourceJSON();
 
             // Run validator on json definition
             this.onDefinitionChanged();
@@ -95,25 +95,33 @@ export class ResourceComponent implements OnInit {
       });
   }
 
+  private generateSampleData(): void {
+    this.generateResource(true);
+    this.onDefinitionChanged();
+  }
+ 
   /**
    * Generate the json description of a resource
    */
-  private generateResource(): void {
+  private generateResource(withSampleData?: boolean): void {
     let businessNetworkDefinition = this.clientService.getBusinessNetwork();
     let factory = businessNetworkDefinition.getFactory();
     let idx = Math.round(Math.random() * 9999).toString();
     idx = leftPad(idx, 4, '0');
     let id = `${this.resourceDeclaration.getIdentifierFieldName()}:${idx}`;
-    let resource = factory.newResource(this.resourceDeclaration.getModelFile().getNamespace(), this.resourceDeclaration.getName(), id, { generate: true });
+    let resource = factory.newResource(
+      this.resourceDeclaration.getModelFile().getNamespace(),
+      this.resourceDeclaration.getName(),
+      id,
+      { generate: true, "withSampleData": withSampleData });
     let serializer = this.clientService.getBusinessNetwork().getSerializer();
     try {
       let json = serializer.toJSON(resource);
       this.resourceDefinition = JSON.stringify(json, null, 2);
-      this.onDefinitionChanged();
     } catch (error) {
       // We can't generate a sample instance for some reason.
       this.defitionError = error.toString();
-      this.resourceDefinition = this.generateDefinitionStub(this.registryID, this.resourceDeclaration);
+      this.resourceDefinition = "";
     }
   }
 

--- a/packages/composer-playground/src/app/transaction/transaction.component.html
+++ b/packages/composer-playground/src/app/transaction/transaction.component.html
@@ -41,7 +41,7 @@
   </section>
   <footer>
     <p class="footer-text">Just need quick test data?
-      <button type="button" class="icon" (click)="generateTransactionDeclaration()"><u>Generate Random Data</u></button>
+      <button type="button" class="icon" (click)="generateTransactionDeclaration(true)"><u>Generate Random Data</u></button>
     </p>
     <div class="transaction-footer-cta">
       <button type="button" class="secondary" (click)="activeModal.dismiss();">

--- a/packages/composer-playground/src/app/transaction/transaction.component.ts
+++ b/packages/composer-playground/src/app/transaction/transaction.component.ts
@@ -36,8 +36,6 @@ export class TransactionComponent implements OnInit {
   private submitInProgress: boolean = false;
   private defitionError: string = null;
 
-  private generateParameters = {generate : true};
-
   private codeConfig = {
     lineNumbers: true,
     lineWrapping: true,
@@ -103,11 +101,12 @@ export class TransactionComponent implements OnInit {
   /**
    * Generate a TransactionDeclaration definition, accounting for need to hide fields
    */
-  private generateTransactionDeclaration() {
+  private generateTransactionDeclaration(withSampleData?: boolean): void {
     let businessNetworkDefinition = this.clientService.getBusinessNetwork();
     let factory = businessNetworkDefinition.getFactory();
     let id = this.hiddenTransactionItems.get(this.selectedTransaction.getIdentifierFieldName());
-    let resource = factory.newResource(this.selectedTransaction.getModelFile().getNamespace(), this.selectedTransaction.getName(), id, this.generateParameters);
+    const generateParameters = { generate: true, "withSampleData": withSampleData };
+    let resource = factory.newResource(this.selectedTransaction.getModelFile().getNamespace(), this.selectedTransaction.getName(), id, generateParameters);
     let serializer = this.clientService.getBusinessNetwork().getSerializer();
     try {
       let json = serializer.toJSON(resource);


### PR DESCRIPTION
Added a ValueGenerator strategy for use during resource generation. Depending on the arguments supplied to the resource generator, one of two ValueGenerator implementation are used: default values, or sample data. The Test tab in the Playground UI now uses the resource generation code when clicking the Create... button to create a new Asset,