### PR TITLE
Check to see if result is a thenable, don't use instanceof

### DIFF
--- a/packages/composer-runtime/lib/jstransactionexecutor.js
+++ b/packages/composer-runtime/lib/jstransactionexecutor.js
@@ -69,7 +69,7 @@ class JSTransactionExecutor extends TransactionExecutor {
             return result.then(() => {
                 LOG.debug(method, 'Executing function');
                 let funcResult = func(resolvedTransaction);
-                if (funcResult instanceof Promise) {
+                if (funcResult && typeof funcResult.then === 'function') {
                     return funcResult.then(() => {
                         LOG.debug(method, 'Function executed (returned promise)');
                     });


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->

## Checklist
 - [ ]  A link to the issue/user story that the pull request relates to
 - [ ]  How to recreate the problem without the fix
 - [ ]  Design of the fix
 - [ ]  How to prove that the fix works
 - [ ]  Automated tests that prove the fix keeps on working
 - [ ]  Documentation - any JSDoc, website, or Stackoverflow answers?


## Issue/User story
<!--- What issue / user story is this for -->
#565 Playground submitted transactions with errors are not always caught

## Steps to Reproduce
<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug include code to reproduce, if relevant -->
1.
2.
3.
4.


## Existing issues
<!-- Have you searched for any existing issues or are their any similar issues that you've found? -->
- [ ] [StackOverflow issues](http://stackoverflow.com/tags/fabric-composer)
- [ ] [GitHub Issues](https://github.com/fabric-composer/fabric-composer/issues)
- [ ] [Rocket Chat history](https://chat.hyperledger.org/channel/fabric-composer)

<!-- please include any links to issues here -->

## Design of the fix
<!-- Focus on why you designed this fix this way, and what was discounted. Do not describe just the code - we can read that! -->

## Validation of the fix
<!-- Over and above the tests, what has been done to prove this works? -->

## Automated Tests
<!-- Please describe the automated tests that are put in place to stop this recurring -->

## What documentation has been provided for this pull request
<!-- JSDocs, WebSite and answers to StackOverflow questions are possible documentation sources -->