### PR TITLE
Fix broken links

### DIFF
--- a/packages/composer-website/jekylldocs/business-network/deploybusinessnetwork.md
+++ b/packages/composer-website/jekylldocs/business-network/deploybusinessnetwork.md
@@ -13,7 +13,7 @@ excerpt: How to deploy a Business Network
 A business network is deployed using the `composer network deploy` command.
 
 ## Procedure
-1. Before deploying a business network, a [Business Network Definition](../business-network/businessnetworkdefinition.html) is needed as a `zip` file with the following structure:
+1. Before deploying a business network, a [Business Network Definition](../introduction/businessnetworkdefinition.html) is needed as a `zip` file with the following structure:
 
     ```
     BusinessNetworkArchive.zip
@@ -26,13 +26,13 @@ A business network is deployed using the `composer network deploy` command.
 
     -	**lib** contains all of the transactions processor functions
     -	**models** contains all of the model files written in the [CTO Language](../reference/cto_language.html).
-    -	**package.json** is required, and is used to create the [Business Network Definition](../business-network/businessnetworkdefinition.html)'s identifier
+    -	**package.json** is required, and is used to create the [Business Network Definition](../introduction/businessnetworkdefinition.html)'s identifier
 
     You can use the `composer archive` command to create an archive with the correct format.
 
     **NOTE**: *Do not zip a a folder containing **lib**, **models**, and **package.json** to create an Business Network Archive, zip the contents themselves*
 
-2. Start [Hyperledger Fabric Peer and Membership Service](runtime-start.md)
+2. Start [Hyperledger Fabric Peer and Membership Service](../installing/runtime-start.md)
 
 3. [Create a Connection Profile](../installing/createconnectionprofile.html) or do *not* use `-p` and allow Fabric Composer to create a `Default Connection Profile` for you.
 

--- a/packages/composer-website/jekylldocs/introduction/participantsandidentities.md
+++ b/packages/composer-website/jekylldocs/introduction/participantsandidentities.md
@@ -64,6 +64,6 @@ function to use.
 
 ## Related Reference
 
-[Participant add command](../reference/participant-add.html)  
-[Identity issue command](../reference/identity-issue.html)  
-[Identity revoke command](../reference/identity-revoke.html)  
+[Participant add command](../reference/composer.participant.add.html)  
+[Identity issue command](../reference/composer.identity.issue.html)  
+[Identity revoke command](../reference/composer.identity.revoke.html)  

--- a/packages/composer-website/jekylldocs/tutorials/getting-started-cmd-line.md
+++ b/packages/composer-website/jekylldocs/tutorials/getting-started-cmd-line.md
@@ -62,7 +62,7 @@ All the resources and scripts you'll need are in a git repository that we'll clo
 
 The first thing to do is to ensure that you have a suitable system ready for development.
 
-**Ensure that you have followed the steps in our [Quickstart](./quickstart.md) before continuing!**
+**Ensure that you have followed the steps in our [Quickstart](../installing/quickstart.md) before continuing!**
 
 Let's go ahead and make a change to start to show how easy it is to develop with Fabric Composer.
 
@@ -226,8 +226,8 @@ We have downloaded the Hyperledger docker containers and stated a fabric. We hav
 
 If you want to continue exploring, check out our other Getting Started guides:
 
-[Coding a Business Network Definition](./getting-started-coding-bnd.md)
+[Coding a Business Network Definition](../business-network/getting-started-coding-bnd.md)
 
-[Generating a REST API](./getting-started-rest-api.md)
+[Generating a REST API](../integrating/getting-started-rest-api.md)
 
-[Writing a Node.js App](./getting-started-nodejs-app.md)
+[Writing a Node.js App](../applications/getting-started-nodejs-app.md)


### PR DESCRIPTION
Broken links appear to have been introduced following some md file name changes 

## Issue/User story
#614

## Steps to Reproduce
inspect links reported in listed issue above

## Design of the fix
fix links

## Validation of the fix
followed links manually on jekyll serve

