### PR TITLE
update resource and transaction tests

### DIFF
--- a/packages/composer-playground/src/app/editor/editor.component.ts
+++ b/packages/composer-playground/src/app/editor/editor.component.ts
@@ -236,8 +236,8 @@ export class EditorComponent implements OnInit {
   openExportModal() {
     return this.clientService.getBusinessNetwork().toArchive().then((exportedData) => {
       let file = new File([exportedData],
-        this.clientService.getBusinessNetworkName() + '.bna',
-        {type: 'application/octet-stream'});
+                          this.clientService.getBusinessNetworkName() + '.bna',
+                          {type: 'application/octet-stream'});
       saveAs(file);
       this.alertService.successStatus$.next(this.clientService.getBusinessNetworkName() + '.bna was exported');
     });

--- a/packages/composer-playground/src/app/resource/resource.component.html
+++ b/packages/composer-playground/src/app/resource/resource.component.html
@@ -15,7 +15,8 @@
         <p class="resource-preview-text">JSON Data Preview</p>
       </div>
        <div class="resource-bound">
-        <codemirror [(ngModel)]="resourceDefinition" [config]="codeConfig" (ngModelChange)="onDefinitionChanged()" width="100%" height="100%">
+        <codemirror name="codeMirror" [(ngModel)]="resourceDefinition" [config]="codeConfig" (ngModelChange)="onDefinitionChanged()"
+                    width="100%" height="100%" ngDefaultControl>
         </codemirror>
         <div class="resource-error-text" ng-if="definitionError!=null">
           <p>{{definitionError}}</p>
@@ -25,11 +26,11 @@
     </section>
   </section>
   <footer>
-    <p class="footer-text" *ngIf="!editMode()">Just need quick test data? <button type="button" class="icon" (click)="generateSampleData()"><u>Generate Random Data</u></button></p>
+    <p class="footer-text" *ngIf="!editMode()">Just need quick test data? <button type="button" class="icon" (click)="generateResource(true)"><u>Generate Random Data</u></button></p>
     <button type="button" class="secondary" (click)="activeModal.close();">
       <span>Cancel</span>
     </button>
-    <button type="button" class="primary" (click)="addOrUpdateResource()" [disabled]="definitionError!=null || actionInProgress ">
+    <button id="createResourceButton" type="button" class="primary" (click)="addOrUpdateResource()" [disabled]="definitionError!=null || actionInProgress ">
       <div *ngIf="!actionInProgress">
         <span>{{resourceAction}}</span>
       </div>

--- a/packages/composer-playground/src/app/resource/resource.component.spec.ts
+++ b/packages/composer-playground/src/app/resource/resource.component.spec.ts
@@ -43,6 +43,7 @@ class MockCodeMirrorComponent {
 describe('ResourceComponent', () => {
   let component: ResourceComponent;
   let fixture: ComponentFixture<ResourceComponent>;
+  let element: HTMLElement;
 
   let mockNgbActiveModal;
   let mockClientService;
@@ -124,7 +125,6 @@ describe('ResourceComponent', () => {
       component['retrieveResourceType'] = sandbox.stub();
       component['generateResource'] = sandbox.stub();
       component['onDefinitionChanged'] = sandbox.stub();
-      component['getResourceJSON'] = sandbox.stub();
       mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
       mockClassDeclaration.getFullyQualifiedName.returns('org.acme.fqn');
       mockIntrospector.getClassDeclarations.returns([mockClassDeclaration]);
@@ -141,8 +141,6 @@ describe('ResourceComponent', () => {
       component['retrieveResourceType'].should.be.called;
       component['editMode'].should.be.called;
       component['generateResource'].should.be.called;
-      component['onDefinitionChanged'].should.be.called;
-      component['getResourceJSON'].should.be.called;
     }));
 
     it('should prepare to edit a resource', fakeAsync(() => {
@@ -151,8 +149,6 @@ describe('ResourceComponent', () => {
       tick();
       component['retrieveResourceType'].should.be.called;
       component['editMode'].should.be.called;
-      component['onDefinitionChanged'].should.be.called;
-      component['getResourceJSON'].should.be.called;
       component['generateResource'].should.not.be.called;
     }));
 
@@ -164,7 +160,6 @@ describe('ResourceComponent', () => {
       component['retrieveResourceType'].should.not.be.called;
       component['editMode'].should.not.be.called;
       component['onDefinitionChanged'].should.not.be.called;
-      component['getResourceJSON'].should.not.be.called;
       component['generateResource'].should.not.be.called;
     }));
   });
@@ -182,17 +177,6 @@ describe('ResourceComponent', () => {
     });
   });
 
-  describe('#generateSampleData', () => {
-    it('should call generateResource and onDefinitionChanged', () => {
-      sandbox.stub(component, 'generateResource');
-      sandbox.stub(component, 'onDefinitionChanged');
-      component['generateSampleData']();
-      component['generateResource'].should.be.called;
-      component['generateResource'].should.be.calledWith(true);
-      component['onDefinitionChanged'].should.be.called;
-    });
-  });
-
   describe('#generateResource', () => {
     let mockClassDeclaration;
     let mockModelFile;
@@ -202,34 +186,70 @@ describe('ResourceComponent', () => {
       mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
       mockClassDeclaration.getModelFile.returns(mockModelFile);
       mockClassDeclaration.getName.returns('class.declaration');
-      mockSerializer.toJSON.returns({'$class': 'com.org'});
+      mockClassDeclaration.getIdentifierFieldName.returns('resourceId');
+      
     });
 
     it('should generate a valid resource', () => {
+
+      mockSerializer.toJSON.returns({'$class': 'com.org'});   
+      mockSerializer.fromJSON.returns(mockResource); 
+      mockResource.validate = sandbox.stub(); 
       component['resourceDeclaration'] = mockClassDeclaration;
+
+      // should start clean
+      should.not.exist(component['definitionError']);
+
+      // run method
       component['generateResource']();
+
+      // should not result in definitionError
+      should.not.exist(component['definitionError']);
+
+      // resourceDefinition should be set as per serializer.toJSON output
       component['resourceDefinition'].should.equal('{\n  "$class": "com.org"\n}');
+
+      // We use the following internal calls
+      mockFactory.newResource.should.be.called;
+      component.onDefinitionChanged.should.be.calledOn;
     });
 
-    it('should set definitionError', () => {
+    it('should set definitionError on serializer fail', () => {
+      component['resourceDeclaration'] = mockClassDeclaration;
+      
+      // Set serializer to throw
       mockSerializer.toJSON = () => {
         throw new Error('error');
       };
-      component['resourceDeclaration'] = mockClassDeclaration;
+
+      // should start clean
+      should.not.exist(component['definitionError']);
+      
+      // Run method
       component['generateResource']();
+
+      // should be in error state
       should.exist(component['definitionError']);
     });
-  });
 
-  describe('#getResourceJSON', () => {
-    it('should return stringified json', () => {
-      let json = {
-        '$class': 'com.acme',
+    it('should set definitionError on validation fail', () => {
+      mockSerializer.toJSON.returns({'$class': 'com.org'});   
+      mockSerializer.fromJSON.returns(mockResource); 
+      component['resourceDeclaration'] = mockClassDeclaration;
+
+      // Set validate to throw
+      mockResource.validate = () => {
+        throw new Error('error');
       };
-      component['resource'] = mockResource;
-      mockSerializer.toJSON.returns(json);
-      const result = component['getResourceJSON']();
-      result.should.equal(JSON.stringify(json, null, 2));
+
+      // should start clean
+      should.not.exist(component['definitionError']);
+
+      // Run method
+      component['generateResource']();
+
+      // should be in error state
+      should.exist(component['definitionError']);
     });
   });
 
@@ -247,7 +267,7 @@ describe('ResourceComponent', () => {
       sandbox.restore();
     });
 
-    it('should add a resource', fakeAsync(() => {
+    it('should call registry add and close the modal', fakeAsync(() => {
       component['editMode'] = sandbox.stub().returns(false);
       component['resourceDefinition'] = '{"class": "org.acme"}';
       mockSerializer.fromJSON.returns(mockResource);
@@ -265,7 +285,7 @@ describe('ResourceComponent', () => {
       mockNgbActiveModal.close.should.be.called;
     }));
 
-    it('should update a resource', fakeAsync(() => {
+    it('should call registry update and close the modal', fakeAsync(() => {
       component['editMode'] = sandbox.stub().returns(true);
       component['resourceDefinition'] = '{"class": "org.acme"}';
       mockSerializer.fromJSON.returns(mockResource);
@@ -283,7 +303,7 @@ describe('ResourceComponent', () => {
       mockNgbActiveModal.close.should.be.called;
     }));
 
-    it('should set definitionError', fakeAsync(() => {
+    it('should set definitionError if error thrown', fakeAsync(() => {
       component['resourceDefinition'] = 'will error';
 
       component['addOrUpdateResource']();
@@ -312,6 +332,51 @@ describe('ResourceComponent', () => {
       component['onDefinitionChanged']();
       should.exist(component['definitionError']);
     });
+
+    it('should show definition errors to users', () => {
+      
+      // Insert definition error
+      component['definitionError'] = 'Error: forced error content';
+      
+      // Check that the UI is showing the error
+      fixture.detectChanges();      
+      element = fixture.debugElement.query(By.css('.resource-error-text')).nativeElement;
+      element.textContent.should.contain('Error: forced error content');
+
+    });
+
+     it('should disable the create resource button if definition error present', () => {
+      
+      // Insert definition error
+      component['definitionError'] = 'Error: forced error content';
+          
+      // Check that the transaction submission button is disabled in UI
+      fixture.detectChanges();
+      element = fixture.debugElement.query(By.css('#createResourceButton')).nativeElement;      
+      (element as HTMLButtonElement).disabled.should.be.true;
+
+    });
+
+    it('should re-enable the create resource button if definition error is fixed', () => {
+     
+      // Insert definition error
+      component['definitionError'] = 'Error: forced error content';
+      
+      // Check that the transaction submission button is disabled
+      fixture.detectChanges();
+      element = fixture.debugElement.query(By.css('#createResourceButton')).nativeElement;      
+      (element as HTMLButtonElement).disabled.should.be.true;
+
+      // Fix the definition error
+      component['definitionError'] = undefined;
+       
+      // Check that the transaction submission button is enabled
+      fixture.detectChanges();
+      element = fixture.debugElement.query(By.css('#createResourceButton')).nativeElement;      
+      (element as HTMLButtonElement).disabled.should.be.false;
+
+    });
+
   });
 
   describe('#retrieveResourceType', () => {
@@ -340,24 +405,6 @@ describe('ResourceComponent', () => {
     });
   });
 
-  describe('#generateDefinitionStub', () => {
-    it('should return a json schema stub', () => {
-      let registryId = 'com.acme.registry';
-      let mockClassDeclaration = sinon.createStubInstance(ClassDeclaration);
-      let mockProperty1 = sinon.createStubInstance(Property);
-      mockProperty1.getName.returns('prop1');
-      let mockProperty2 = sinon.createStubInstance(Property);
-      mockProperty2.getName.returns('prop2');
-      mockClassDeclaration.getProperties.returns([
-        mockProperty1,
-        mockProperty2
-      ]);
-
-      let result = component['generateDefinitionStub'](registryId, mockClassDeclaration);
-      result.should.equal('{\n  "$class": "com.acme.registry",\n  "prop1": "",\n  "prop2": ""\n}');
-    });
-  });
-
   describe('#retrieveResourceRegistry', () => {
     it('should return an AssetRegistry', () => {
       let registryId = 'registryId';
@@ -370,7 +417,7 @@ describe('ResourceComponent', () => {
       result.should.equal('testing');
     });
 
-    it('should return an PerticipantRegistry', () => {
+    it('should return a ParticipantRegistry', () => {
       let registryId = 'registryId';
       component['registryID'] = registryId;
       mockBusinessNetworkConnection.getParticipantRegistry.returns('testing');

--- a/packages/composer-playground/src/app/resource/resource.component.ts
+++ b/packages/composer-playground/src/app/resource/resource.component.ts
@@ -79,15 +79,13 @@ export class ResourceComponent implements OnInit {
 
             if (this.editMode()) {
                 this.resourceAction = 'Update';
+                let serializer = this.clientService.getBusinessNetwork().getSerializer();
+                this.resourceDefinition = JSON.stringify(serializer.toJSON(this.resource), null, 2);
             } else {
                 // Stub out json definition
                 this.resourceAction = 'Create New';
                 this.generateResource();
             }
-            this.resourceDefinition = this.getResourceJSON();
-
-            // Run validator on json definition
-            this.onDefinitionChanged();
           }
         });
 
@@ -96,11 +94,6 @@ export class ResourceComponent implements OnInit {
 
   private editMode(): boolean {
       return (this.resource ? true : false);
-  }
-
-  private generateSampleData(): void {
-    this.generateResource(true);
-    this.onDefinitionChanged();
   }
 
   /**
@@ -122,6 +115,7 @@ export class ResourceComponent implements OnInit {
         let serializer = this.clientService.getBusinessNetwork().getSerializer();
         let json = serializer.toJSON(resource);
         this.resourceDefinition = JSON.stringify(json, null, 2);
+        this.onDefinitionChanged();
     } catch (error) {
         // We can't generate a sample instance for some reason.
         this.definitionError = error.toString();
@@ -129,10 +123,6 @@ export class ResourceComponent implements OnInit {
     }
   }
 
-  private getResourceJSON(): any {
-    let serializer = this.clientService.getBusinessNetwork().getSerializer();
-    return JSON.stringify(serializer.toJSON(this.resource), null, 2);
-  }
 
   /**
    *  Create resource via json serialisation
@@ -165,15 +155,15 @@ export class ResourceComponent implements OnInit {
   /**
    * Validate json definition of resource
    */
-  private onDefinitionChanged() {
+  onDefinitionChanged() {
     try {
       let json = JSON.parse(this.resourceDefinition);
       let serializer = this.clientService.getBusinessNetwork().getSerializer();
       let resource = serializer.fromJSON(json);
       resource.validate();
       this.definitionError = null;
-    } catch (e) {
-      this.definitionError = e.toString();
+    } catch (error) {
+      this.definitionError = error.toString();
     }
   }
 
@@ -188,20 +178,6 @@ export class ResourceComponent implements OnInit {
     } else if (modelClassDeclaration instanceof ParticipantDeclaration) {
       return 'Participant';
     }
-  }
-
-  /**
-   * Generate a stub resource definition
-   */
-  private generateDefinitionStub(registryID, modelClassDeclaration): string {
-    let stub = '';
-    stub = '{\n  "$class": "' + registryID + '"';
-    let resourceProperties = modelClassDeclaration.getProperties();
-    resourceProperties.forEach((property) => {
-      stub += ',\n  "' + property.getName() + '": ""';
-    });
-    stub += '\n}';
-    return stub;
   }
 
   /**

--- a/packages/composer-playground/src/app/transaction/transaction.component.html
+++ b/packages/composer-playground/src/app/transaction/transaction.component.html
@@ -29,8 +29,8 @@
           <p class="resource-preview-text">JSON Data Preview</p>
         </div>
         <div class="resource-bound">
-          <codemirror [(ngModel)]="resourceDefinition" [config]="codeConfig" (ngModelChange)="onDefinitionChanged()"
-                      width="100%" height="100%">
+          <codemirror name="codeMirror" [(ngModel)]="resourceDefinition" [config]="codeConfig" (ngModelChange)="onDefinitionChanged()"
+                      width="100%" height="100%" ngDefaultControl>
           </codemirror>
           <div class="resource-error-text" ng-if="definitionError!=null">
             <p>{{definitionError}}</p>
@@ -47,12 +47,12 @@
       <button type="button" class="secondary" (click)="activeModal.dismiss();">
         <span>Cancel</span>
       </button>
-      <button type="button" class="primary" (click)="submitTransaction()"
-              [disabled]="definitionError!=null || submitInProgress">
-        <div *ngIf="!submitInProgress">
+      <button name="submitButton" id="submitTransactionButton" type="button" class="primary" (click)="submitTransaction()"
+              [disabled]="definitionError!=null || submitInProgress" ngDefaultControl>
+        <div *ngIf="!submitInProgress" ngDefaultControl>
           <span>Submit</span>
         </div>
-        <div *ngIf="submitInProgress" class="ibm-spinner-indeterminate small loop">
+        <div *ngIf="submitInProgress" class="ibm-spinner-indeterminate small loop" ngDefaultControl>
           <div class="loader">
             <svg class="circular" viewBox="25 25 50 50">
               <circle class="circle-path" cx="50" cy="50" r="20"/>

--- a/packages/composer-playground/src/app/transaction/transaction.component.ts
+++ b/packages/composer-playground/src/app/transaction/transaction.component.ts
@@ -124,7 +124,7 @@ export class TransactionComponent implements OnInit {
   /**
    * Validate the definition of the TransactionDeclaration, accounting for hidden fields.
    */
-  private onDefinitionChanged() {
+  onDefinitionChanged() {
     try {
       let json = JSON.parse(this.resourceDefinition);
       // Add required items that are hidden from user


### PR DESCRIPTION
Extension of tests per #658 for Resource and Transaction components, inclusive of edits to Transaction component model file to remove redundant code

## Issue/User story
#658



## Design of the fix
Add tests to check UI DOM tree aspects
Refactor existing tests to account for code removal in Resource component model
Refactor existing tests to increase depth of coverage and ensure we are testing expected output

## Validation of the fix
Manual testing
