### PR TITLE
fix(v1): turn on debug logging for composer runtime

### DIFF
--- a/packages/composer-runtime-hlfv1/chaincode.go
+++ b/packages/composer-runtime-hlfv1/chaincode.go
@@ -36,6 +36,10 @@ func NewChaincode() (result *Chaincode) {
 // Init is called by the Hyperledger Fabric when the chaincode is deployed.
 // Init can read from and write to the world state.
 func (chaincode *Chaincode) Init(stub shim.ChaincodeStubInterface) (response pb.Response) {
+	//TODO: Need to control this via env var and/or api call.
+	//logging needs to be set here again as the fabric chaincode disables it
+	//even though it was enabled in main.
+	logger.SetLevel(shim.LogDebug)
 	logger.Debug("Entering Chaincode.Init", stub)
 	defer func() { logger.Debug("Exiting Chaincode.Init", response) }()
 

--- a/packages/composer-runtime-hlfv1/composerpool.go
+++ b/packages/composer-runtime-hlfv1/composerpool.go
@@ -22,7 +22,7 @@ type ComposerPool struct {
 // NewComposerPool creates a new pool of Composer objects.
 func NewComposerPool(max int) (result *ComposerPool) {
 	logger.Debug("Entering NewComposerPool", max)
-	defer func() { logger.Debug("Exiting NewChaincode", result) }()
+	defer func() { logger.Debug("Exiting NewComposerPool", result) }()
 
 	return &ComposerPool{
 		Pool: make(chan *Composer, max),

--- a/packages/composer-runtime-hlfv1/main.go
+++ b/packages/composer-runtime-hlfv1/main.go
@@ -26,6 +26,8 @@ var logger = shim.NewLogger("Composer")
 // main starts the shim, which establishes the connection to the Hyperledger
 // Fabric and registers the chaincode for deploys, queries, and invokes.
 func main() {
+	//TODO: Need to control this via env var and/or api call.
+	logger.SetLevel(shim.LogDebug)
 	logger.Debug("Entering main")
 	defer func() { logger.Debug("Exiting main") }()
 	chaincode := NewChaincode()


### PR DESCRIPTION
enable debug logging for composer in HLFV1 as it is completely off and not controllable at present making debug difficult.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>