### PR TITLE
fix(cli): address all issues with spinner and useful error messages

### DIFF
--- a/packages/composer-cli/lib/cmds/network/lib/deploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/deploy.js
@@ -85,7 +85,11 @@ class Deploy {
             // Read archive file contents
             archiveFileContents = Deploy.getArchiveFileContents(argv.archiveFile);
             // Get the connection ioptions
-            connectOptions = Deploy.getConnectOptions(connectionProfileName);
+            try {
+                connectOptions = Deploy.getConnectOptions(connectionProfileName);
+            } catch (error) {
+                throw new Error('Failed to read connection profile \'' + connectionProfileName + '\'. Error was ' + error);
+            }
             return BusinessNetworkDefinition.fromArchive(archiveFileContents);
         })
         .then ((result) => {

--- a/packages/composer-cli/lib/cmds/network/lib/download.js
+++ b/packages/composer-cli/lib/cmds/network/lib/download.js
@@ -101,7 +101,9 @@ class Download {
 
         }).catch( (error) => {
             console.log(error);
-            spinner.fail();
+            if (spinner) {
+                spinner.fail();
+            }
             throw error;
         })
         ;

--- a/packages/composer-cli/lib/cmds/network/lib/list.js
+++ b/packages/composer-cli/lib/cmds/network/lib/list.js
@@ -131,7 +131,9 @@ class List {
             return businessNetworkConnection.disconnect();
         })
         .catch(error => {
-            spinner.fail();
+            if (spinner) {
+                spinner.fail();
+            }
             console.log(List.getError(error));
         });
     }

--- a/packages/composer-cli/lib/cmds/network/lib/undeploy.js
+++ b/packages/composer-cli/lib/cmds/network/lib/undeploy.js
@@ -74,7 +74,9 @@ class Undeploy {
               spinner.succeed();
               return result;
           }).catch((error) => {
-              spinner.fail();
+              if (spinner) {
+                  spinner.fail();
+              }
               throw error;
           });
     }

--- a/packages/composer-cli/lib/cmds/transaction/lib/submit.js
+++ b/packages/composer-cli/lib/cmds/transaction/lib/submit.js
@@ -68,7 +68,7 @@ class Submit {
                 try {
                     data = JSON.parse(data);
                 } catch(e) {
-                    throw new Error('JSON error. Are have you quoted the JSON string?', e);
+                    throw new Error('JSON error. Have you quoted the JSON string?', e);
                 }
             } else {
                 throw new Error('Data must be a string');

--- a/packages/composer-common/lib/fsconnectionprofilestore.js
+++ b/packages/composer-common/lib/fsconnectionprofilestore.js
@@ -84,7 +84,7 @@ class FSConnectionProfileStore extends ConnectionProfileStore {
             })
             .catch((err) => {
                 LOG.error('load','Failed to loaded connection profile ' + connectionProfile, err);
-                throw new Error('Failed to load connection profile ' + connectionProfile);
+                throw new Error('Failed to load connection profile ' + connectionProfile + '. Error was ' + err);
             });
     }
 


### PR DESCRIPTION
Address all places where the error
‘TypeError: Cannot read property 'fail' of undefined’
and ensure error message indicates the problem is in a connection profile and why.

Signed-off-by: Dave Kelsey <d_kelsey@uk.ibm.com>
